### PR TITLE
Support benchmarking of vLLM advanced features

### DIFF
--- a/fmperf/loadgen/generate-input.py
+++ b/fmperf/loadgen/generate-input.py
@@ -47,14 +47,19 @@ def get_streaming_response(response: requests.Response):
                 prev_completion_tokens = usage["completion_tokens"]
                 for i in range(token_count):
                     yield {
-                        'index': out['index'],
-                        'text': '' if (i < token_count - 1) else out['text'],
-                        'logprobs': None,
-                        'finish_reason': None if (i < token_count - 1) else out['finish_reason'],
-                        'stop_reason': None if (i < token_count - 1) else out['stop_reason']
+                        "index": out["index"],
+                        "text": "" if (i < token_count - 1) else out["text"],
+                        "logprobs": None,
+                        "finish_reason": (
+                            None if (i < token_count - 1) else out["finish_reason"]
+                        ),
+                        "stop_reason": (
+                            None if (i < token_count - 1) else out["stop_reason"]
+                        ),
                     }
             else:
                 raise RuntimeError("No usage data in server response")
+
 
 def get_text():
     if args.import_text:
@@ -87,7 +92,7 @@ def generate_vllm_request(config, url):
         "max_tokens": config["out_tokens"],
         "seed": 42,
         "stream": True,
-        "stream_options" : { "include_usage": True, "continuous_usage_stats": True }
+        "stream_options": {"include_usage": True, "continuous_usage_stats": True},
     }
 
     if not args.from_model:

--- a/fmperf/loadgen/generate-input.py
+++ b/fmperf/loadgen/generate-input.py
@@ -54,8 +54,7 @@ def get_streaming_response(response: requests.Response):
                         'stop_reason': None if (i < token_count - 1) else out['stop_reason']
                     }
             else:
-                #raise Exception("No usage data in server response")
-                print("No usage data in server response")
+                raise RuntimeError("No usage data in server response")
 
 def get_text():
     if args.import_text:

--- a/fmperf/loadgen/run.py
+++ b/fmperf/loadgen/run.py
@@ -55,11 +55,15 @@ def run():
                     prev_completion_tokens = usage["completion_tokens"]
                     for i in range(token_count):
                         yield {
-                            'index': out['index'],
-                            'text': '' if (i < token_count - 1) else out['text'],
-                            'logprobs': None,
-                            'finish_reason': None if (i < token_count - 1) else out['finish_reason'],
-                            'stop_reason': None if (i < token_count - 1) else out['stop_reason']
+                            "index": out["index"],
+                            "text": "" if (i < token_count - 1) else out["text"],
+                            "logprobs": None,
+                            "finish_reason": (
+                                None if (i < token_count - 1) else out["finish_reason"]
+                            ),
+                            "stop_reason": (
+                                None if (i < token_count - 1) else out["stop_reason"]
+                            ),
                         }, 1, timestamp, True, None
             except Exception as e:
                 timestamp = time.time_ns()

--- a/fmperf/utils/Parsing.py
+++ b/fmperf/utils/Parsing.py
@@ -60,15 +60,15 @@ def parse_results(results, print_df=False, print_csv=False):
 
     df_out["latency_prefill_ms"] = df_prefill.groupby(["exp_num_users"])[
         "duration_ms"
-    ].median()
+    ].mean()
     df_out["latency_nexttoken_ms"] = df_nexttoken.groupby(["exp_num_users"])[
         "duration_ms"
-    ].median()
+    ].mean()
     df_out["latency_e2e_ms"] = (
         df.groupby(["exp_num_users", "worker_idx", "request_idx"])["duration_ms"]
         .sum()
         .groupby("exp_num_users")
-        .median()
+        .mean()
     )
 
     with pd.option_context(


### PR DESCRIPTION
Supports issue #27.

This PR enables fmperf to exploit the usage statistics that vLLM since recently can include in every single streaming response, for correctly determining the token count when chunked prefill or speculative decoding have been enabled.