### PR TITLE
Move the imports of the tgis grpc stubs to where they are used

### DIFF
--- a/fmperf/loadgen/generate-input.py
+++ b/fmperf/loadgen/generate-input.py
@@ -133,7 +133,11 @@ def generate_tgis_request(config, url):
     Generate (streaming) gRPC request and expected response
     """
 
-    from text_generation_tests.pb import generation_pb2_grpc as gpb2, generation_pb2 as pb2
+    from text_generation_tests.pb import (
+        generation_pb2_grpc as gpb2,
+        generation_pb2 as pb2,
+    )
+
     channel = grpc.insecure_channel(url)
     stub = gpb2.GenerationServiceStub(channel)
 

--- a/fmperf/loadgen/generate-input.py
+++ b/fmperf/loadgen/generate-input.py
@@ -6,7 +6,6 @@ import os
 import grpc
 import pickle
 from google.protobuf import json_format
-from text_generation_tests.pb import generation_pb2_grpc as gpb2, generation_pb2 as pb2
 import requests
 from typing import Iterable, List
 from importlib import resources as impresources
@@ -134,6 +133,7 @@ def generate_tgis_request(config, url):
     Generate (streaming) gRPC request and expected response
     """
 
+    from text_generation_tests.pb import generation_pb2_grpc as gpb2, generation_pb2 as pb2
     channel = grpc.insecure_channel(url)
     stub = gpb2.GenerationServiceStub(channel)
 

--- a/fmperf/loadgen/run.py
+++ b/fmperf/loadgen/run.py
@@ -9,7 +9,6 @@ import numpy as np
 from text_generation_tests.approx import approx
 import grpc
 from google.protobuf import json_format
-from text_generation_tests.pb import generation_pb2_grpc as gpb2, generation_pb2 as pb2
 from fmperf.utils import parse_results
 from datetime import datetime
 from .collect_energy import collect_metrics, summarize_energy
@@ -88,6 +87,7 @@ def run():
         rs = np.random.RandomState(seed=wid)
 
         if target == "tgis":
+            from text_generation_tests.pb import generation_pb2_grpc as gpb2
             stub = gpb2.GenerationServiceStub(channel)
 
         t_start = time.time_ns()
@@ -111,6 +111,7 @@ def run():
                     stream=True,
                 )
             elif target == "tgis":
+                from text_generation_tests.pb import generation_pb2 as pb2
                 message = json_format.ParseDict(
                     sample_request, pb2.SingleGenerationRequest()
                 )

--- a/fmperf/loadgen/run.py
+++ b/fmperf/loadgen/run.py
@@ -6,7 +6,7 @@ import pandas as pd
 import os
 from durations import Duration
 import numpy as np
-from text_generation_tests.approx import approx
+from fmperf.utils.approx import approx
 import grpc
 from google.protobuf import json_format
 from fmperf.utils import parse_results

--- a/fmperf/loadgen/run.py
+++ b/fmperf/loadgen/run.py
@@ -88,6 +88,7 @@ def run():
 
         if target == "tgis":
             from text_generation_tests.pb import generation_pb2_grpc as gpb2
+
             stub = gpb2.GenerationServiceStub(channel)
 
         t_start = time.time_ns()
@@ -112,6 +113,7 @@ def run():
                 )
             elif target == "tgis":
                 from text_generation_tests.pb import generation_pb2 as pb2
+
                 message = json_format.ParseDict(
                     sample_request, pb2.SingleGenerationRequest()
                 )

--- a/fmperf/utils/approx.py
+++ b/fmperf/utils/approx.py
@@ -1,0 +1,85 @@
+# Copied from https://github.com/IBM/text-generation-inference/blob/main/integration_tests/text_generation_tests/approx.py
+from typing import List
+
+import pytest
+from collections.abc import Mapping, Sized
+from _pytest.python_api import ApproxMapping, ApproxSequenceLike
+
+# This is a hacky extension of pytest's approx function, to get it to work with
+# arbitrarily nested dict/list type objects. Any contained floats are compared with a tolerance.
+
+
+def approx(expected, rel=5e-4, abs=1e-9, nan_ok=False):
+    if isinstance(expected, Mapping):
+        return ApproxNestedMapping(expected, rel, abs, nan_ok)
+    if is_seq_like(expected):
+        return ApproxNestedSequenceLike(expected, rel, abs, nan_ok)
+    return pytest.approx(expected, rel, abs, nan_ok)
+
+
+class ApproxNestedMapping(ApproxMapping):
+    def _check_type(self):
+        return
+
+    def __repr__(self) -> str:
+        return "approx({!r})".format(
+            {k: approx(v) for k, v in self.expected.items()}
+        )
+
+    def _yield_comparisons(self, actual):
+        if set(self.expected.keys()) != set(actual.keys()):
+            return [(self.expected, actual)]
+        return _yield_comparisons(self, super(), actual)
+
+    def _repr_compare(self, other_side) -> List[str]:
+        #TODO impl more useful explanation here
+        try:
+            return super()._repr_compare(other_side)
+        except:
+            return ["Mismatch"]
+
+
+class ApproxNestedSequenceLike(ApproxSequenceLike):
+    def _check_type(self):
+        return
+
+    def __repr__(self) -> str:
+        seq_type = type(self.expected)
+        if seq_type not in (tuple, list):
+            seq_type = list
+        return "approx({!r})".format(
+            seq_type(approx(x) for x in self.expected)
+        )
+
+    def _yield_comparisons(self, actual):
+        if len(self.expected) != len(actual):
+            return [(self.expected, actual)]
+        return _yield_comparisons(self, super(), actual)
+
+    def _repr_compare(self, other_side) -> List[str]:
+        #TODO impl more useful explanation here
+        try:
+            return super()._repr_compare(other_side)
+        except:
+            return ["Mismatch"]
+
+
+def _yield_nested(actual, expected, **kwargs):
+    if isinstance(expected, Mapping):
+        return ApproxNestedMapping(expected, **kwargs)._yield_comparisons(actual)
+    if is_seq_like(expected):
+        return ApproxNestedSequenceLike(expected, **kwargs)._yield_comparisons(actual)
+    return [(actual, expected)]
+
+
+def _yield_comparisons(self, supr, actual):
+    for actual, expected in supr._yield_comparisons(actual):
+        for a, e in _yield_nested(
+                actual, expected, rel=self.rel, abs=self.abs, nan_ok=self.nan_ok
+        ):
+            yield a, e
+
+
+def is_seq_like(obj):
+    return hasattr(obj, "__getitem__") and isinstance(obj, Sized) \
+        and not isinstance(obj, (bytes, str))

--- a/fmperf/utils/approx.py
+++ b/fmperf/utils/approx.py
@@ -22,9 +22,7 @@ class ApproxNestedMapping(ApproxMapping):
         return
 
     def __repr__(self) -> str:
-        return "approx({!r})".format(
-            {k: approx(v) for k, v in self.expected.items()}
-        )
+        return "approx({!r})".format({k: approx(v) for k, v in self.expected.items()})
 
     def _yield_comparisons(self, actual):
         if set(self.expected.keys()) != set(actual.keys()):
@@ -32,7 +30,7 @@ class ApproxNestedMapping(ApproxMapping):
         return _yield_comparisons(self, super(), actual)
 
     def _repr_compare(self, other_side) -> List[str]:
-        #TODO impl more useful explanation here
+        # TODO impl more useful explanation here
         try:
             return super()._repr_compare(other_side)
         except:
@@ -47,9 +45,7 @@ class ApproxNestedSequenceLike(ApproxSequenceLike):
         seq_type = type(self.expected)
         if seq_type not in (tuple, list):
             seq_type = list
-        return "approx({!r})".format(
-            seq_type(approx(x) for x in self.expected)
-        )
+        return "approx({!r})".format(seq_type(approx(x) for x in self.expected))
 
     def _yield_comparisons(self, actual):
         if len(self.expected) != len(actual):
@@ -57,7 +53,7 @@ class ApproxNestedSequenceLike(ApproxSequenceLike):
         return _yield_comparisons(self, super(), actual)
 
     def _repr_compare(self, other_side) -> List[str]:
-        #TODO impl more useful explanation here
+        # TODO impl more useful explanation here
         try:
             return super()._repr_compare(other_side)
         except:
@@ -75,11 +71,14 @@ def _yield_nested(actual, expected, **kwargs):
 def _yield_comparisons(self, supr, actual):
     for actual, expected in supr._yield_comparisons(actual):
         for a, e in _yield_nested(
-                actual, expected, rel=self.rel, abs=self.abs, nan_ok=self.nan_ok
+            actual, expected, rel=self.rel, abs=self.abs, nan_ok=self.nan_ok
         ):
             yield a, e
 
 
 def is_seq_like(obj):
-    return hasattr(obj, "__getitem__") and isinstance(obj, Sized) \
+    return (
+        hasattr(obj, "__getitem__")
+        and isinstance(obj, Sized)
         and not isinstance(obj, (bytes, str))
+    )


### PR DESCRIPTION
With this change we can run with the vLLM backend without having to install this dependency.