### PR TITLE
Make the base directory for requests configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,5 +82,6 @@ WORKDIR /home/fmperf
 # Set permissions for openshift
 RUN chmod -R g+rwx /home/fmperf
 
+ENV REQUESTS_DIR=/requests
 # Sanity check: We can import the installed wheel
 RUN python -c "import ${SOURCE_DIR}"

--- a/fmperf/loadgen/generate-input.py
+++ b/fmperf/loadgen/generate-input.py
@@ -13,6 +13,7 @@ from importlib import resources as impresources
 import fmperf.data
 import traceback
 from transformers import AutoTokenizer
+from fmperf.utils.constants import REQUESTS_DIR
 
 # read in seed text
 seed_text_file = impresources.files(fmperf.data) / "ai.txt"
@@ -202,7 +203,7 @@ url = os.environ["URL"]
 # overwrite
 overwrite = os.getenv("OVERWRITE", "false").lower() != "false"
 
-if os.path.isfile("/requests/%s" % (filename)) and not overwrite:
+if os.path.isfile("%s%s" % (REQUESTS_DIR, filename)) and not overwrite:
     print("File %s already exists; skipping workload generation" % (filename))
     sys.exit()
 
@@ -283,5 +284,5 @@ for sample_idx in range(sample_size):
 
 if len(cases) > 0:
     print(">> Writing %d requests to %s" % (len(cases), filename))
-    with open("/requests/%s" % (filename), "w") as f:
+    with open("%s%s" % (REQUESTS_DIR, filename), "w") as f:
         json.dump(cases, f)

--- a/fmperf/loadgen/generate-text-from-quac.py
+++ b/fmperf/loadgen/generate-text-from-quac.py
@@ -4,6 +4,7 @@ import os
 import random
 import requests
 from typing import List, Tuple
+from fmperf.utils.constants import REQUESTS_DIR
 
 
 class QuACScenario:
@@ -167,7 +168,7 @@ def main():
     quac = QuACScenario()
     prompts = quac.get_prompts()
 
-    filename = "/requests/sample_texts.json"
+    filename = "{REQUESTS_DIR}/sample_texts.json"
     print(">> Writing to %s" % (filename))
     with open(filename, "w") as f:
         json.dump(prompts, f, ensure_ascii=False)

--- a/fmperf/loadgen/run.py
+++ b/fmperf/loadgen/run.py
@@ -13,6 +13,7 @@ from text_generation_tests.pb import generation_pb2_grpc as gpb2, generation_pb2
 from fmperf.utils import parse_results
 from datetime import datetime
 from .collect_energy import collect_metrics, summarize_energy
+from fmperf.utils.constants import REQUESTS_DIR, REQUESTS_FILENAME, RESULTS_ALL_FILENAME
 
 
 def run():
@@ -72,8 +73,8 @@ def run():
         # we have stopped
         yield None, 0, time.time_ns(), False, StopIteration()
 
-    infile = "/requests/%s" % (os.environ["REQUESTS_FILENAME"])
-    outfile = "/requests/%s" % (os.environ["RESULTS_FILENAME"])
+    infile = "%s%s" % (REQUESTS_DIR, REQUESTS_FILENAME)
+    outfile = "%s%s" % (REQUESTS_DIR, RESULTS_FILENAME)
     target = os.environ["TARGET"]
     api_url = os.environ["URL"]
     num_users = int(os.environ["NUM_USERS"])

--- a/fmperf/loadgen/sweep.py
+++ b/fmperf/loadgen/sweep.py
@@ -2,6 +2,7 @@ import os
 import json
 from .run import run
 from fmperf.utils import parse_results
+from fmperf.utils.constants import REQUESTS_DIR, RESULTS_ALL_FILENAME
 
 users = [int(u) for u in os.environ["SWEEP_USERS"].split(",")]
 
@@ -13,7 +14,7 @@ for u in users:
 
     run()
 
-    filename = "/requests/result_sweep_u%d.json" % (u)
+    filename = "%srequests/result_sweep_u%d.json" % (REQUESTS_DIR, u)
 
     with open(filename, "rb") as f:
         tmp = json.load(f)
@@ -22,7 +23,7 @@ for u in users:
 
     parse_results(results, print_df=True)
 
-outfile = f"/requests/{os.environ['RESULTS_ALL_FILENAME']}"
+outfile = f"{REQUESTS_DIR}{RESULTS_ALL_FILENAME}"
 print(f">> writing all results to file: {outfile}")
 with open(outfile, "w") as f:
     json.dump(results, f)

--- a/fmperf/utils/constants.py
+++ b/fmperf/utils/constants.py
@@ -1,0 +1,5 @@
+import os
+
+REQUESTS_DIR=(lambda s: s + "/" if len(s) > 1 and not s.endswith("/") else s)(os.environ.get("REQUESTS_DIR", ""))
+REQUESTS_FILENAME = os.environ["REQUESTS_FILENAME"]
+RESULTS_ALL_FILENAME = os.environ['RESULTS_ALL_FILENAME']


### PR DESCRIPTION
The `/requests` path was hardcoded in a bunch of places making it difficult to install fmperf in a running container where you don't have root access to `mkdir /create`.

I've added an environment variable that defaults to "" so that all paths become local. If the path is not empty the code makes sure that there is an "/" at the end to concatenate the paths.

To prevent breaking existing scripts, in the Dockerfile the environment variable is set to `/requests`