### PR TITLE
Fix paths that are broken when sweep is executed

### DIFF
--- a/fmperf/loadgen/run.py
+++ b/fmperf/loadgen/run.py
@@ -15,7 +15,9 @@ from .collect_energy import collect_metrics, summarize_energy
 from fmperf.utils.constants import REQUESTS_DIR, REQUESTS_FILENAME, RESULTS_ALL_FILENAME
 
 
-def run():
+def run(result_filename = None):
+    if result_filename is None:
+        result_filename = RESULTS_ALL_FILENAME
     def get_streaming_response_tgis(response):
         stop = False
         generated_tokens = 0
@@ -73,7 +75,7 @@ def run():
         yield None, 0, time.time_ns(), False, StopIteration()
 
     infile = os.path.join(REQUESTS_DIR, REQUESTS_FILENAME)
-    outfile = os.path.join(REQUESTS_DIR, RESULTS_FILENAME)
+    outfile = os.path.join(REQUESTS_DIR, result_filename)
     target = os.environ["TARGET"]
     api_url = os.environ["URL"]
     num_users = int(os.environ["NUM_USERS"])

--- a/fmperf/loadgen/run.py
+++ b/fmperf/loadgen/run.py
@@ -15,9 +15,10 @@ from .collect_energy import collect_metrics, summarize_energy
 from fmperf.utils.constants import REQUESTS_DIR, REQUESTS_FILENAME, RESULTS_ALL_FILENAME
 
 
-def run(result_filename = None):
+def run(result_filename=None):
     if result_filename is None:
         result_filename = RESULTS_ALL_FILENAME
+
     def get_streaming_response_tgis(response):
         stop = False
         generated_tokens = 0

--- a/fmperf/loadgen/sweep.py
+++ b/fmperf/loadgen/sweep.py
@@ -10,11 +10,12 @@ results = []
 
 for u in users:
     os.environ["NUM_USERS"] = str(u)
-    os.environ["RESULTS_FILENAME"] = "result_sweep_u%d.json" % (u)
 
-    run()
+    result_filename = "result_sweep_u%d.json" % (u)
 
-    filename = os.path.join(REQUESTS_DIR, "requests/result_sweep_u%d.json" % (u))
+    run(result_filename)
+
+    filename = os.path.join(REQUESTS_DIR, result_filename)
 
     with open(filename, "rb") as f:
         tmp = json.load(f)
@@ -23,7 +24,7 @@ for u in users:
 
     parse_results(results, print_df=True)
 
-outfile = os.path.point(REQUESTS_DIR, RESULTS_ALL_FILENAME)
+outfile = os.path.join(REQUESTS_DIR, RESULTS_ALL_FILENAME)
 print(f">> writing all results to file: {outfile}")
 with open(outfile, "w") as f:
     json.dump(results, f)


### PR DESCRIPTION
With the constants refactoring, the code that ran the sweep case and relied on modifying environment variables stopped working.