### PR TITLE
Add Makefile, separate core and development requirements

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -21,6 +21,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e .
         pip install -r requirements.txt
+        pip install -r requirements-dev.txt
 
     - name: Run tests
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,13 +31,14 @@ WORKDIR /app
 ## Dev Dependencies Layer ######################################################
 FROM base as dev_dependencies
 
-COPY requirements.txt /app/requirements.txt
+COPY requirements.txt requirements-dev.txt /app/
 
 # speed up pip installs by caching a directory across builds
 # https://pythonspeed.com/articles/docker-cache-pip-downloads/
 RUN --mount=type=cache,target=/root/.cache \
     true \
     && pip install -r /app/requirements.txt \
+    && pip install -r /app/requirements-dev.txt \
     && true
 
 # Install kustomize

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,88 @@
+SHELL := /usr/bin/env bash
+VENV := .venv
+
+##@ General
+
+# The help target prints out all targets with their descriptions organized
+# beneath their categories. The categories are represented by '##@' and the
+# target descriptions by '##'. The awk commands is responsible for reading the
+# entire set of makefiles included in this invocation, looking for lines of the
+# file as xyz: ## something, and then pretty-format the target and help. Then,
+# if there's a line with ##@ something, that gets pretty-printed as a category.
+# More info on the usage of ANSI control characters for terminal formatting:
+# https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters
+# More info on the awk command:
+# http://linuxcommand.org/lc3_adv_awk.php
+
+.PHONY: help
+help: ## Print help
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+.PHONY: install
+install: ## Install core requirements
+	@echo "Installing core requirements..."
+	pip install -r requirements.txt
+
+.PHONY: venv
+venv: ## Create a Python virtual environment with core requirements
+	@echo "Creating virtual environment..."
+	@if [ ! -d $(VENV) ]; then \
+	    python3 -m venv $(VENV); \
+		source $(VENV)/bin/activate; \
+		pip install --upgrade pip; \
+	else \
+		echo "Virtual environment already exists, leaving as-is"; \
+		exit 1; \
+	fi
+	@echo "Installing core dependencies..."
+	@source $(VENV)/bin/activate; pip install -r requirements.txt; pip install -e .;
+	@printf "\nRun \033[35msource $(VENV)/bin/activate\033[0m to activate the virtual environment\n"
+
+##@ Development
+
+.PHONY: format
+format: ## Autoformat code
+	@echo "Formatting Python code..."
+	ruff format ./fmperf
+	ruff format ./examples
+	@echo "Sorting requirements..."
+	@for req in $$(ls requirements*.txt); do sort -f $$req -o $$req; done
+
+.PHONY: lint
+lint: ## Perform linting
+	black --check ./fmperf
+	black --check ./examples
+
+.PHONY: type-check
+type-check: ## Perform type checking
+	@echo "Running type checking with mypy..."
+	mypy --strict ./fmperf
+	mypy --strict ./examples
+
+.PHONY: test
+test: ## Run tests
+	pytest fmperf/tests/
+
+.PHONY: install-dev
+install-dev: ## Install development requirements
+	@echo "Installing development requirements..."
+	pip install -r requirements-dev.txt
+
+.PHONY: install-all
+install-all: install install-dev ## Install core and development requirements
+
+.PHONY: venv-dev
+venv-dev: venv ## Create a Python virtual environment with core and dev requirements
+	@echo "Installing dev dependencies..."
+	@source $(VENV)/bin/activate; pip install -r requirements-dev.txt
+	@printf "\nRun \033[35msource $(VENV)/bin/activate\033[0m to activate the virtual environment\n"
+
+.PHONY: clean
+clean: ## Remove cache, backup, and temporary files
+	@echo "Running cleanup"
+	find fmperf/ -depth -name '__pycache__' -exec rm -vrf {} \;
+	rm -vrf fmperf.egg-info
+	find -depth -name '.pytest_cache' -exec rm -vrf {} \;
+	find -depth -name '.ipynb_checkpoints' -exec rm -vrf {} \;
+	ruff clean
+	rm -rf .mypy_cache

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ venv: ## Create a Python virtual environment with core requirements
 		pip install --upgrade pip; \
 	else \
 		echo "Virtual environment already exists, no action needed."; \
-		exit 0; \
+		exit 1; \
 	fi
 	@echo "Installing core dependencies..."
 	@source $(VENV)/bin/activate; pip install -r requirements.txt; pip install -e .;

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ VENV := .venv
 
 # The help target prints out all targets with their descriptions organized
 # beneath their categories. The categories are represented by '##@' and the
-# target descriptions by '##'. The awk commands is responsible for reading the
+# target descriptions by '##'. The awk command is responsible for reading the
 # entire set of makefiles included in this invocation, looking for lines of the
 # file as xyz: ## something, and then pretty-format the target and help. Then,
 # if there's a line with ##@ something, that gets pretty-printed as a category.

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,8 @@ venv: ## Create a Python virtual environment with core requirements
 		source $(VENV)/bin/activate; \
 		pip install --upgrade pip; \
 	else \
-		echo "Virtual environment already exists, leaving as-is"; \
-		exit 1; \
+		echo "Virtual environment already exists, no action needed."; \
+		exit 0; \
 	fi
 	@echo "Installing core dependencies..."
 	@source $(VENV)/bin/activate; pip install -r requirements.txt; pip install -e .;

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+black~=24.0
+mypy>=1.14.1
+pytest
+ruff>=0.9.4
+wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,7 @@
+durations
 kubernetes==24.2.0
-black~=24.0
 pandas
 pyyaml
-pytest
-wheel
 scikit-learn
-durations
-transformers
 sentencepiece
+transformers


### PR DESCRIPTION
In this PR:
- Separate core and development requirements into `requirements.txt` and `requirements-dev.txt`
- Create a `Makefile` for performing common tasks

I kept `black` as the linter unchanged, but added `ruff` as a formatter and `mypy` as a type checker for consistency with Inference Perf (however, they are running with default options here).
